### PR TITLE
Update ubuntu-wine.sh

### DIFF
--- a/ubuntu-wine.sh
+++ b/ubuntu-wine.sh
@@ -2,7 +2,7 @@ if [ -z "$DISPLAY" ]; then
     export DISPLAY=:0.0
 fi
 
-if ! $(lsb_release -a | grep -q -e "18.04" -e "18.10" -e "19.04"); then
+if ! $(lsb_release -a | grep -q -e "18.04" -e "18.10" -e "19.10"); then     #Changed from 19.04 --> 19.10
   echo "You need at least Ubuntu 18.04"
   exit 1
 fi
@@ -24,8 +24,8 @@ if $(lsb_release -a | grep -q -e "18.10"); then
   sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ cosmic main'
 fi
 
-if $(lsb_release -a | grep -q -e "19.04"); then
-  sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ disco main'
+if $(lsb_release -a | grep -q -e "19.10"); then
+  sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ eoan main'
 fi
 
 sudo add-apt-repository ppa:cybermax-dexter/sdl2-backport -y
@@ -33,7 +33,7 @@ sudo add-apt-repository ppa:cybermax-dexter/sdl2-backport -y
 sudo apt update
 
 # install wine-staging
-sudo apt -y install --install-recommends winehq-staging
+sudo apt install --install-recommends winehq-staging
 
 # install winetricks
 sudo apt -y install winetricks


### PR DESCRIPTION
When trying to use Ubuntu 19.10, the installer rejects me for not having Ubuntu 19.04. Not sure if this is a good fix, but it worked for me.